### PR TITLE
More informative error messages in build_gene_annots

### DIFF
--- a/R/build_annotations.R
+++ b/R/build_annotations.R
@@ -513,11 +513,12 @@ build_gene_annots = function(genome = annotatr::builtin_genomes(), annotations =
         stringsAsFactors = FALSE)
 
     # Load the appropriate TxDb.* library and get the txdb
+    err_mess = NULL
     txdb_name = get_txdb_name(genome)
     if(requireNamespace(txdb_name, quietly = TRUE)) {
         library(txdb_name, character.only = TRUE)
     } else {
-        stop(sprintf('The package %s is not installed, please install it via Bioconductor.', txdb_name))
+        err_mess = sprintf('The package %s is not installed, please install it via Bioconductor.', txdb_name)
     }
     txdb = get(txdb_name)
 
@@ -527,8 +528,12 @@ build_gene_annots = function(genome = annotatr::builtin_genomes(), annotations =
     if(requireNamespace(sprintf('org.%s.eg.db', orgdb_name), quietly = TRUE)) {
         library(sprintf('org.%s.eg.db', orgdb_name), character.only = TRUE)
     } else {
-        stop(sprintf('The package org.%s.eg.db is not installed, please install it via Bioconductor.', orgdb_name))
+        err_mess <- paste(err_mess, 
+                          sprintf('The package org.%s.eg.db is not installed, please install it via Bioconductor.', orgdb_name),
+                          sep='\n')
     }
+    if(!is.null(err_mess))
+        stop(err_mess)
     x = get(sprintf('org.%s.egSYMBOL', orgdb_name))
     mapped_genes = mappedkeys(x)
     eg2symbol = as.data.frame(x[mapped_genes])

--- a/R/build_annotations.R
+++ b/R/build_annotations.R
@@ -527,7 +527,7 @@ build_gene_annots = function(genome = annotatr::builtin_genomes(), annotations =
     if(requireNamespace(sprintf('org.%s.eg.db', orgdb_name), quietly = TRUE)) {
         library(sprintf('org.%s.eg.db', orgdb_name), character.only = TRUE)
     } else {
-        stop(sprintf('The package %s is not installed, please install it via Bioconductor.', orgdb_name))
+        stop(sprintf('The package org.%s.eg.db is not installed, please install it via Bioconductor.', orgdb_name))
     }
     x = get(sprintf('org.%s.egSYMBOL', orgdb_name))
     mapped_genes = mappedkeys(x)


### PR DESCRIPTION
Include full name of orgdb annotation package in the error message
if missing; delay stop() until both txdb and orgdb packages are 
checked and include both in error message if they are missing.